### PR TITLE
[Style] Blocking Print Commands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "edu.wpi.first.GradleRIO" version "2026.2.1"
     id "com.diffplug.spotless" version "6.25.0"
     id("io.freefair.lombok") version "9.2.0"
+    id "checkstyle"
 
 }
 
@@ -136,4 +137,9 @@ spotless {
         endWithNewline()
         trimTrailingWhitespace()
     }
+}
+
+checkstyle {
+    toolVersion = "10.12.5"
+    configFile = file("config/checkstyle/checkstyle.xml")
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="System\.out\.print"/>
+      <property name="message" value="System.out.print* is not allowed. Use DataLogManager.log() instead, or '// print-allow-override' to override."/>
+      <property name="ignoreComments" value="true"/>
+    </module>
+    <module name="SuppressWithNearbyCommentFilter">
+      <property name="commentFormat" value="print-allow-override"/>
+      <property name="checkFormat" value="RegexpSinglelineJava"/>
+      <property name="influenceFormat" value="0"/>
+    </module>
+  </module>
+</module>

--- a/src/main/java/frc/robot/subsystems/Launcher/Hood.java
+++ b/src/main/java/frc/robot/subsystems/Launcher/Hood.java
@@ -15,6 +15,7 @@ import edu.wpi.first.networktables.DoubleTopic;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.TimestampedDouble;
 import edu.wpi.first.units.measure.Voltage;
+import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -145,7 +146,7 @@ public class Hood extends SubsystemBase {
 
   public void setHoodPosition(double positionRotations) {
     if (!hoodZeroed) {
-      System.out.println("Hood not zero'd!");
+      DataLogManager.log("Hood not zero'd!");
       return;
     }
     hood.setControl(request.withPosition(positionRotations));

--- a/src/main/java/frc/robot/test/AutomatedTestRobot.java
+++ b/src/main/java/frc/robot/test/AutomatedTestRobot.java
@@ -1,6 +1,7 @@
 package frc.robot.test;
 
 import edu.wpi.first.hal.simulation.DriverStationDataJNI;
+import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.DriverStation;
 import frc.robot.Robot;
 
@@ -9,12 +10,12 @@ public class AutomatedTestRobot extends Robot {
     try {
       Thread.sleep(durationMillis);
     } catch (InterruptedException interrupt) {
-      System.out.println("Interrupted");
+      DataLogManager.log("Interrupted");
     }
   }
 
   public AutomatedTestRobot() {
-    System.out.println("Robot type: Automated test");
+    DataLogManager.log("Robot type: Automated test");
   }
 
   @Override
@@ -39,21 +40,21 @@ public class AutomatedTestRobot extends Robot {
   }
 
   private void runTest() {
-    System.out.println("Waiting two seconds for robot to finish startup");
+    DataLogManager.log("Waiting two seconds for robot to finish startup");
     sleep(2000);
 
-    System.out.println("Enabling autonomous mode and waiting 10 seconds");
+    DataLogManager.log("Enabling autonomous mode and waiting 10 seconds");
     DriverStationDataJNI.setAutonomous(true);
     DriverStationDataJNI.setEnabled(true);
 
     sleep(10000);
 
-    System.out.println("Disabling robot and waiting two seconds");
+    DataLogManager.log("Disabling robot and waiting two seconds");
     DriverStationDataJNI.setEnabled(false);
 
     sleep(2000);
 
-    System.out.println("Ending competition");
+    DataLogManager.log("Ending competition");
     suppressExitWarning(true);
     endCompetition();
   }

--- a/src/main/java/frc/robot/util/BuildInfo.java
+++ b/src/main/java/frc/robot/util/BuildInfo.java
@@ -104,7 +104,7 @@ public class BuildInfo {
         // Check commit hash header
         String commitHashHeader = scanner.nextLine();
         if (!lineIsHeader(commitHashHeader, "Commit hash")) {
-          System.out.println("No git!");
+          DataLogManager.log("No git!");
           throw new InvalidFormatException();
         }
         // Read the commit hash

--- a/src/main/java/frc/robot/util/LimelightHelpers.java
+++ b/src/main/java/frc/robot/util/LimelightHelpers.java
@@ -20,6 +20,7 @@ import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.TimestampedDoubleArray;
+import edu.wpi.first.wpilibj.DataLogManager;
 import frc.robot.util.LimelightHelpers.LimelightResults;
 import frc.robot.util.LimelightHelpers.PoseEstimate;
 import java.io.IOException;
@@ -852,37 +853,37 @@ public class LimelightHelpers {
    */
   public static void printPoseEstimate(PoseEstimate pose) {
     if (pose == null) {
-      System.out.println("No PoseEstimate available.");
+      DataLogManager.log("No PoseEstimate available.");
       return;
     }
 
-    System.out.printf("Pose Estimate Information:%n");
-    System.out.printf("Timestamp (Seconds): %.3f%n", pose.timestampSeconds);
-    System.out.printf("Latency: %.3f ms%n", pose.latency);
-    System.out.printf("Tag Count: %d%n", pose.tagCount);
-    System.out.printf("Tag Span: %.2f meters%n", pose.tagSpan);
-    System.out.printf("Average Tag Distance: %.2f meters%n", pose.avgTagDist);
-    System.out.printf("Average Tag Area: %.2f%% of image%n", pose.avgTagArea);
-    System.out.printf("Is MegaTag2: %b%n", pose.isMegaTag2);
-    System.out.println();
+    DataLogManager.log("Pose Estimate Information:");
+    DataLogManager.log(String.format("Timestamp (Seconds): %.3f", pose.timestampSeconds));
+    DataLogManager.log(String.format("Latency: %.3f ms", pose.latency));
+    DataLogManager.log(String.format("Tag Count: %d", pose.tagCount));
+    DataLogManager.log(String.format("Tag Span: %.2f meters", pose.tagSpan));
+    DataLogManager.log(String.format("Average Tag Distance: %.2f meters", pose.avgTagDist));
+    DataLogManager.log(String.format("Average Tag Area: %.2f%% of image", pose.avgTagArea));
+    DataLogManager.log(String.format("Is MegaTag2: %b", pose.isMegaTag2));
+    DataLogManager.log("");
 
     if (pose.rawFiducials == null || pose.rawFiducials.length == 0) {
-      System.out.println("No RawFiducials data available.");
+      DataLogManager.log("No RawFiducials data available.");
       return;
     }
 
-    System.out.println("Raw Fiducials Details:");
+    DataLogManager.log("Raw Fiducials Details:");
     for (int i = 0; i < pose.rawFiducials.length; i++) {
       RawFiducial fiducial = pose.rawFiducials[i];
-      System.out.printf(" Fiducial #%d:%n", i + 1);
-      System.out.printf("  ID: %d%n", fiducial.id);
-      System.out.printf("  TXNC: %.2f%n", fiducial.txnc);
-      System.out.printf("  TYNC: %.2f%n", fiducial.tync);
-      System.out.printf("  TA: %.2f%n", fiducial.ta);
-      System.out.printf("  Distance to Camera: %.2f meters%n", fiducial.distToCamera);
-      System.out.printf("  Distance to Robot: %.2f meters%n", fiducial.distToRobot);
-      System.out.printf("  Ambiguity: %.2f%n", fiducial.ambiguity);
-      System.out.println();
+      DataLogManager.log(String.format(" Fiducial #%d:", i + 1));
+      DataLogManager.log(String.format("  ID: %d", fiducial.id));
+      DataLogManager.log(String.format("  TXNC: %.2f", fiducial.txnc));
+      DataLogManager.log(String.format("  TYNC: %.2f", fiducial.tync));
+      DataLogManager.log(String.format("  TA: %.2f", fiducial.ta));
+      DataLogManager.log(String.format("  Distance to Camera: %.2f meters", fiducial.distToCamera));
+      DataLogManager.log(String.format("  Distance to Robot: %.2f meters", fiducial.distToRobot));
+      DataLogManager.log(String.format("  Ambiguity: %.2f", fiducial.ambiguity));
+      DataLogManager.log("");
     }
   }
 
@@ -1739,7 +1740,7 @@ public class LimelightHelpers {
     double millis = (end - start) * .000001;
     results.latency_jsonParse = millis;
     if (profileJSON) {
-      System.out.printf("lljson: %.2f\r\n", millis);
+      DataLogManager.log(String.format("lljson: %.2f", millis));
     }
 
     return results;


### PR DESCRIPTION
System.Out.printX() can cause performance issues for a robot at run-time and is 300x worse than without it in code.  In general, it's better to use DataLogManager.log().  (See Issue #43 for details)

By default - code will fail to compile and recommend the developer to use DataLogManager.log() instead of System.out.println().  However, this can be bypassed or overridden with a comment of //print-allow-override for cases where it is truly needed. 