### PR TITLE
Issue 188: Rotation2d x and y are 0

### DIFF
--- a/src/main/java/frc/robot/subsystems/launcher/LaunchCalculator.java
+++ b/src/main/java/frc/robot/subsystems/launcher/LaunchCalculator.java
@@ -46,6 +46,7 @@ public class LaunchCalculator {
   private static final double MIN_SLOPE = 1e-4;
   private static final int NEWTON_METHOD_MAX_ITERATIONS = 5;
   private static final double VFF_DIST_TOLERANCE = 0.1;
+  private static final double ARCTAN_NEAR_ZERO = 1e-4;
 
   // Trench stuff
   private static final AprilTagFieldLayout field = AllianceUtils.FIELD_LAYOUT;
@@ -233,9 +234,17 @@ public class LaunchCalculator {
     Translation2d virtualTarget =
         new Translation2d(target.getX() - turretVelocityX * t, target.getY() - turretVelocityY * t);
 
-    Rotation2d targetAngleFieldRelative =
-        virtualTarget.minus(turretPose.getTranslation()).getAngle();
-
+    // subtract the two translation 2ds
+    Translation2d targetDifference = virtualTarget.minus(turretPose.getTranslation());
+    Rotation2d targetAngleFieldRelative;
+    // If the distance is practically zero (0.../0...)
+    if (targetDifference.getNorm() < ARCTAN_NEAR_ZERO) {
+      // Just set it to zero so we don't call arctan and throw exceptions for divide by zero
+      targetAngleFieldRelative = Rotation2d.kZero;
+    } else {
+      // It's difference is big enough, so use it
+      targetAngleFieldRelative = targetDifference.getAngle();
+    }
     // FINAL NUMS
     double targetHood = getHoodAngle(estimatedPose, trueDistance, chassisSpeeds);
     double targetFlywheels = LauncherConstants.getFlywheelSpeedFromDistance(trueDistance);

--- a/src/main/java/frc/robot/subsystems/launcher/LaunchCalculator.java
+++ b/src/main/java/frc/robot/subsystems/launcher/LaunchCalculator.java
@@ -46,7 +46,8 @@ public class LaunchCalculator {
   private static final double MIN_SLOPE = 1e-4;
   private static final int NEWTON_METHOD_MAX_ITERATIONS = 5;
   private static final double VFF_DIST_TOLERANCE = 0.1;
-  private static final double ARCTAN_NEAR_ZERO = 1e-4;
+  // Originally 1e-4 without square norm. With square norm it's (1e-4)^2
+  private static final double MIN_DISTANCE_TO_TARGET_SQUARED = 1e-8;
 
   // Trench stuff
   private static final AprilTagFieldLayout field = AllianceUtils.FIELD_LAYOUT;
@@ -236,14 +237,16 @@ public class LaunchCalculator {
 
     // subtract the two translation 2ds
     Translation2d targetDifference = virtualTarget.minus(turretPose.getTranslation());
+    double dx = targetDifference.getX();
+    double dy = targetDifference.getY();
     Rotation2d targetAngleFieldRelative;
     // If the distance is practically zero (0.../0...)
-    if (targetDifference.getNorm() < ARCTAN_NEAR_ZERO) {
+    if (dx * dx + dy * dy < MIN_DISTANCE_TO_TARGET_SQUARED) {
       // Just set it to zero so we don't call arctan and throw exceptions for divide by zero
       targetAngleFieldRelative = Rotation2d.kZero;
     } else {
-      // It's difference is big enough, so use it
-      targetAngleFieldRelative = targetDifference.getAngle();
+      // Its' difference is big enough, so use it
+      targetAngleFieldRelative = new Rotation2d(dx, dy);
     }
     // FINAL NUMS
     double targetHood = getHoodAngle(estimatedPose, trueDistance, chassisSpeeds);

--- a/src/main/java/frc/robot/subsystems/launcher/LaunchCalculator.java
+++ b/src/main/java/frc/robot/subsystems/launcher/LaunchCalculator.java
@@ -46,8 +46,7 @@ public class LaunchCalculator {
   private static final double MIN_SLOPE = 1e-4;
   private static final int NEWTON_METHOD_MAX_ITERATIONS = 5;
   private static final double VFF_DIST_TOLERANCE = 0.1;
-  // Originally 1e-4 without square norm. With square norm it's (1e-4)^2
-  private static final double MIN_DISTANCE_TO_TARGET_SQUARED = 1e-8;
+  private static final double MIN_DISTANCE_TO_TARGET = 1e-4;
 
   // Trench stuff
   private static final AprilTagFieldLayout field = AllianceUtils.FIELD_LAYOUT;
@@ -232,21 +231,12 @@ public class LaunchCalculator {
           (tangentialVel / trueDistance) - chassisSpeeds.omegaRadiansPerSecond; // RAD/S
     }
 
-    Translation2d virtualTarget =
-        new Translation2d(target.getX() - turretVelocityX * t, target.getY() - turretVelocityY * t);
-
-    // subtract the two translation 2ds
-    Translation2d targetDifference = virtualTarget.minus(turretPose.getTranslation());
-    double dx = targetDifference.getX();
-    double dy = targetDifference.getY();
     Rotation2d targetAngleFieldRelative;
-    // If the distance is practically zero (0.../0...)
-    if (dx * dx + dy * dy < MIN_DISTANCE_TO_TARGET_SQUARED) {
-      // Just set it to zero so we don't call arctan and throw exceptions for divide by zero
+    if (trueDistance < MIN_DISTANCE_TO_TARGET) {
       targetAngleFieldRelative = Rotation2d.kZero;
     } else {
-      // Its' difference is big enough, so use it
-      targetAngleFieldRelative = new Rotation2d(dx, dy);
+      // We still pass dx and dy to the constructor so it stays "linked" to the vector
+      targetAngleFieldRelative = new Rotation2d(trueDistanceX, trueDistanceY);
     }
     // FINAL NUMS
     double targetHood = getHoodAngle(estimatedPose, trueDistance, chassisSpeeds);


### PR DESCRIPTION
The issue is that atan2 is called even when the turret is really near the hub's center (could be due to vision bugs, testing, etc.). If so, it reports the error along with the stack trace which is incredibly cpu intensive. Now this adds a vector norm check to see if the rotation2d's x and y components are both near 0. If so just make rotation2d 0 degrees.

Exact definition:

```/**
   * Constructs a Rotation2d with the given x and y (cosine and sine) components.
   *
   * @param x The x component or cosine of the rotation.
   * @param y The y component or sine of the rotation.
   */
  public Rotation2d(double x, double y) {
    double magnitude = Math.hypot(x, y);
    if (magnitude > 1e-6) {
      m_cos = x / magnitude;
      m_sin = y / magnitude;
    } else {
      m_cos = 1.0;
      m_sin = 0.0;
      MathSharedStore.reportError(
          "x and y components of Rotation2d are zero\n", Thread.currentThread().getStackTrace());
    }
    m_value = Math.atan2(m_sin, m_cos);
  }