### PR TITLE
Out of Memory issue launching simulator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,13 @@ tasks.withType(JavaCompile) {
     options.compilerArgs.add '-XDstringConcat=inline'
 }
 
+// Increase memory and heap specifically for the robot simulator
+tasks.withType(JavaExec).configureEach {
+    if (name.toLowerCase().contains("simulate")) {
+        jvmArgs "-Xmx4G", "-Xms2G"
+    }
+}
+
 // Spotless
 spotless {
     format "misc", {

--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,7 @@ tasks.withType(JavaCompile) {
 // Increase memory and heap specifically for the robot simulator
 tasks.withType(JavaExec).configureEach {
     if (name.toLowerCase().contains("simulate")) {
-        jvmArgs "-Xmx4G", "-Xms2G"
+        jvmArgs "-Xmx2G", "-Xms2G"
     }
 }
 

--- a/src/main/java/frc/robot/sim/visionproducers/VisionSim.java
+++ b/src/main/java/frc/robot/sim/visionproducers/VisionSim.java
@@ -178,10 +178,10 @@ public class VisionSim implements VisionSimInterface {
         }
 
         // Increase std devs based on (average) distance
-        if (numTags == 1 && avgDist > 4) {
+        if (numTags == 1 && avgDist > 1.3) {
           estStdDevs = VecBuilder.fill(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
         } else {
-          estStdDevs = estStdDevs.times(1 + (avgDist * avgDist / 30));
+          estStdDevs = estStdDevs.times(1 + (avgDist * avgDist / 3.33));
         }
         m_curStdDevs = estStdDevs;
       }

--- a/src/main/java/frc/robot/sim/visionproducers/VisionSimConstants.java
+++ b/src/main/java/frc/robot/sim/visionproducers/VisionSimConstants.java
@@ -31,7 +31,7 @@ public class VisionSimConstants {
   public static final double kCameraFPS = 15;
   public static final double kAvgLatencyMs = 50;
   public static final double kLatencyStdDevMs = 15;
-  public static final double kMinTargetAreaPixels = 10.0;
+  public static final double kMinTargetAreaPixels = 1.1;
   public static final double kMaxSightRangeMeters = 3.0;
 
   /** Per-camera configuration for vision simulation. */

--- a/src/main/java/frc/robot/sim/visionproducers/VisionSimConstants.java
+++ b/src/main/java/frc/robot/sim/visionproducers/VisionSimConstants.java
@@ -26,8 +26,8 @@ public class VisionSimConstants {
   public static final int kCameraResWidth = 320;
   public static final int kCameraResHeight = 240;
   public static final double kCameraFOVDegrees = 90.0;
-  public static final double kCalibErrorAvg = 0.35;
-  public static final double kCalibErrorStdDev = 0.10;
+  public static final double kCalibErrorAvg = 0.12;
+  public static final double kCalibErrorStdDev = 0.035;
   public static final double kCameraFPS = 15;
   public static final double kAvgLatencyMs = 50;
   public static final double kLatencyStdDevMs = 15;

--- a/src/main/java/frc/robot/sim/visionproducers/VisionSimConstants.java
+++ b/src/main/java/frc/robot/sim/visionproducers/VisionSimConstants.java
@@ -23,8 +23,8 @@ public class VisionSimConstants {
   public static final Matrix<N3, N1> kMultiTagStdDevs = VecBuilder.fill(0.5, 0.5, 1);
 
   // Camera simulation properties (shared by all cameras — all cameras are identical)
-  public static final int kCameraResWidth = 960;
-  public static final int kCameraResHeight = 720;
+  public static final int kCameraResWidth = 320;
+  public static final int kCameraResHeight = 240;
   public static final double kCameraFOVDegrees = 90.0;
   public static final double kCalibErrorAvg = 0.35;
   public static final double kCalibErrorStdDev = 0.10;

--- a/src/main/java/frc/robot/sim/visionproducers/VisionSimConstants.java
+++ b/src/main/java/frc/robot/sim/visionproducers/VisionSimConstants.java
@@ -31,7 +31,7 @@ public class VisionSimConstants {
   public static final double kCameraFPS = 15;
   public static final double kAvgLatencyMs = 50;
   public static final double kLatencyStdDevMs = 15;
-  public static final double kMinTargetAreaPixels = 1.1;
+  public static final double kMinTargetAreaPixels = 10.0;
   public static final double kMaxSightRangeMeters = 3.0;
 
   /** Per-camera configuration for vision simulation. */


### PR DESCRIPTION
There have been reports of out-of-memory errors when booting the simulator app.  This PR makes two changes to attempt to address this issue:

1) When running the simulator, we allocate more memory to the process on launch.
2) Reduce the vision from a resolution of 960x720 to 320x240.  In the simulator vision is streaming via the Network Tables the images from 3 cameras simultaneously.  By reducing the resolution, the memory cost of this action is reduced by 90%.