### PR TITLE
Fix serious bug where Named Commands were no longer being registered

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -141,7 +141,7 @@ public class Robot extends TimedRobot {
     SmartDashboard.putData(CommandScheduler.getInstance());
 
     if (SubsystemConstants.DRIVEBASE_ENABLED) {
-      AutoLogic.initCommandsAndPaths();
+      AutoLogic.initCommandsAndPaths(false);
       AutonomousField.initSmartDashBoard(() -> "Field", 0, 0, this::addPeriodic);
 
       AutoLogic.initSmartDashBoard();

--- a/src/main/java/frc/robot/subsystems/auto/AutoLogic.java
+++ b/src/main/java/frc/robot/subsystems/auto/AutoLogic.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.json.simple.parser.ParseException;
 
 public class AutoLogic {

--- a/src/main/java/frc/robot/subsystems/auto/AutoLogic.java
+++ b/src/main/java/frc/robot/subsystems/auto/AutoLogic.java
@@ -94,16 +94,12 @@ public class AutoLogic {
   // We always need to register commands BEFORE we initialize paths.  This is
   // because paths may reference commands or triggers that need to be registered first.
   // This helper-method insures caller initializes these in the correct order.
-  public static void initCommandsAndPaths(Optional<Boolean> testMode) {
-    if (testMode != null && !testMode.orElse(false)) {
+  public static void initCommandsAndPaths(boolean testMode) {
+    if (!testMode) {
       registerCommands();
     }
 
     initPaths();
-  }
-
-  public static void initCommandsAndPaths() {
-    initCommandsAndPaths(Optional.of(true));
   }
 
   private static void initPaths() {

--- a/src/test/java/AutosTest.java
+++ b/src/test/java/AutosTest.java
@@ -23,7 +23,7 @@ class AutosTest {
 
   @Test
   void validateFileName() throws IOException, ParseException {
-    AutoLogic.initCommandsAndPaths();
+    AutoLogic.initCommandsAndPaths(true);
 
     Dictionary<String, Boolean> pathDictionary = new Hashtable<>();
     for (AutoPath path : AutoLogic.getAutos()) { // Every auto in the auto chooser


### PR DESCRIPTION
There's a bug in the following commit that you checked in tonight:
  dfb504bd4f419e714e455793c2b5cc8191797dc8
  fixed event markers and auto commands (#234)

This change was not perfectly copied from Ido's demo-branch.  Instead, an "Optional" was added to AutoLogic::initCommandsAndPaths.  And that logic causes the robot to *never* register any named commands anymore.  Which is a serious issue and can cause autos to no-longer shoot at all.



The bug introduced is this:
Robot calls initCommandsAndPaths() with no params.

...that calls the following version of initCommandsAndPaths with no params:
  public static void initCommandsAndPaths() {
    initCommandsAndPaths(Optional.of(true));
  }

...Note that it passes the testMode boolean parameter as Optional.of(true) - meaning that it will run in 'test mode' which skips initializing Commands.

However, the Robot class constructor *should actually* pass testMode==false when called from Robot class.
Only the unit-test should call with testMode==true.


The fix is to be more explicit in passing testMode==false from Robot's constructor by getting rid of the Optional, and simplifies the code.



I *highly* recommend either:
a) Testing that autos work on the REAL robot extensively after this fix
b) OR, just remove the original commit that was not correctly copied from Ido's branch, and live without paths that can use triggers for worlds?


I lean towards (b), since it's just a few days before Comps (i.e. remove the original feature).  But, you can do (a) as long as autos are tested well on the real robot.  That's fine too.

If you decide to do (b), then ignore this pull request and submit a separate one to undo commit dfb504bd4f419e714e455793c2b5cc8191797dc8.