### PR TITLE
Fix BLine chained path pose resets

### DIFF
--- a/src/main/java/frc/robot/subsystems/auto/BLine/BLineLogic.java
+++ b/src/main/java/frc/robot/subsystems/auto/BLine/BLineLogic.java
@@ -66,6 +66,7 @@ public class BLineLogic {
   private static boolean pathsInitialized = false;
 
   public static FollowPath.Builder pathBuilder;
+  private static FollowPath.Builder continuingPathBuilder;
   private static Command bLineLaunching;
 
   // ========================= INIT =========================
@@ -104,20 +105,23 @@ public class BLineLogic {
 
   public static void configure(Subsystems s) {
 
-    pathBuilder =
-        new FollowPath.Builder(
-                s.drivebaseSubsystem,
-                () -> s.drivebaseSubsystem.getState().Pose,
-                () -> s.drivebaseSubsystem.getState().Speeds,
-                (speeds) ->
-                    s.drivebaseSubsystem.setControl(
-                        new SwerveRequest.ApplyRobotSpeeds()
-                            .withSpeeds(ChassisSpeeds.discretize(speeds, 0.020))),
-                new PIDController(3.0, 0.0, 0.0),
-                new PIDController(5.0, 0.0, 0.0),
-                new PIDController(2.0, 0.0, 0.0))
-            .withDefaultShouldFlip()
-            .withPoseReset(pose -> s.drivebaseSubsystem.resetPose(pose));
+    pathBuilder = createPathBuilder(s).withPoseReset(pose -> s.drivebaseSubsystem.resetPose(pose));
+    continuingPathBuilder = createPathBuilder(s);
+  }
+
+  private static FollowPath.Builder createPathBuilder(Subsystems s) {
+    return new FollowPath.Builder(
+            s.drivebaseSubsystem,
+            () -> s.drivebaseSubsystem.getState().Pose,
+            () -> s.drivebaseSubsystem.getState().Speeds,
+            (speeds) ->
+                s.drivebaseSubsystem.setControl(
+                    new SwerveRequest.ApplyRobotSpeeds()
+                        .withSpeeds(ChassisSpeeds.discretize(speeds, 0.020))),
+            new PIDController(3.0, 0.0, 0.0),
+            new PIDController(5.0, 0.0, 0.0),
+            new PIDController(2.0, 0.0, 0.0))
+        .withDefaultShouldFlip();
   }
 
   // ========================= LOGGING =========================
@@ -211,31 +215,27 @@ public class BLineLogic {
     double delay = autoDelayEntry.getDouble(0.0);
 
     BLinePath path = getSelectedAutoPath();
-    s.drivebaseSubsystem.resetRotation(path.getPath().getInitialModuleDirection());
-    return Commands.waitSeconds(delay).andThen(pathBuilder.build(path.getPath()));
+    return Commands.waitSeconds(delay).andThen(buildPath(path.getPath(), true));
   }
 
   public static Command buildRTNeutralAuto() {
     return Commands.sequence(
         Commands.waitSeconds(autoDelayEntry.getDouble(0.0)),
-        buildAndSetHeading(new Path("RTNEUTRALTEST")), launcherCommand(4));
+        buildPath(new Path("RTNEUTRALTEST"), true), launcherCommand(4));
   }
 
   public static Command buildRTNeutralTestingAuto() {
 
     return Commands.sequence(
         Commands.waitSeconds(autoDelayEntry.getDouble(0.0)),
-        buildAndSetHeading(new Path("RTNEUTRAL")),
+        buildPath(new Path("RTNEUTRAL"), true),
         launcherCommand(3.5),
-        buildAndSetHeading(new Path("RTRBNEUTRAL")),
-            launcherCommand());
+        buildPath(new Path("RTRBNEUTRAL"), false),
+        launcherCommand());
   }
 
-  private static Command buildAndSetHeading(Path path) {
-
-    return Commands.runOnce(
-            () -> s.drivebaseSubsystem.resetRotation(path.getInitialModuleDirection()))
-        .andThen(pathBuilder.build(path));
+  private static Command buildPath(Path path, boolean resetPose) {
+    return (resetPose ? pathBuilder : continuingPathBuilder).build(path);
   }
 
   private static void updateInitialHeading() {


### PR DESCRIPTION
## Summary
- avoid resetting robot rotation from `getInitialModuleDirection()` when building BLine paths
- use a pose-resetting builder for the first path and a non-resetting builder for continuation paths
- route chained autos through `buildPath(path, resetPose)` so only the first path resets odometry

## Root cause
`getInitialModuleDirection()` is a module/wheel direction hint, not the robot odometry heading. Resetting robot rotation to it between paths caused heading snaps. The existing `FollowPath.Builder` also retained `.withPoseReset(...)`, so every later `build(path)` reset pose again.

## Validation
- `./gradlew compileJava -PautomatedTest=true --console=plain`
- `./gradlew test -PautomatedTest=true --console=plain`
- Simulated BLine chained autos with wpilib-agent-tools and inspected WPILOGs in AdvantageScope

## Scope
This PR only changes `src/main/java/frc/robot/subsystems/auto/BLine/BLineLogic.java`. No path JSON, test harness, or generated log files are included.