### PR TITLE
Updated spotless to run on the latest version of Node.js to reduce output errors

### DIFF
--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17


### PR DESCRIPTION
When spotless currently runs it complains that it's running on an old version of Node.js.  This change updates to the latest code which runs on a current version of Node.js and reduces output errors for PR's.